### PR TITLE
Modify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ import { Mongo }    from 'meteor/mongo';
 import { MailTime } from 'meteor/ostrio:mailer';
 
 const MailQueue = new MailTime({
-  db: Mongo.Collection('__mailTimeQueue__').rawDatabase(),
+  db: Meteor.users.rawDatabase(), // We just want to attain the database connection
   type: 'server',
   strategy: 'balancer', // Transports will be used in round robin chain
   transports,


### PR DESCRIPTION
Changed this line: 
  `db: Mongo.Collection('__mailTimeQueue__').rawDatabase(),	`
to: 
`db: Meteor.users.rawDatabase(), // We just want to attain the database connection`

Since the main purpose of db parameter is to attain the database connection, we simply reflect such intent by using Meteor.users as it's always present.

The reasoning behind this pr, is just that we're thrown off by following the docs, thanks!